### PR TITLE
Add scorecard feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ This project provides a simple React application for organising the Portugal Gol
    npm run build
    ```
 
+## Scorecard Functionality
+
+The site includes an interactive scorecard system. Navigate to **Scorecard** from
+the main menu to add players and record hole-by-hole scores for each course. Scores
+are stored in your browser so progress is kept between visits.
+
 ## Improvement Suggestions
 
 Here are some ideas for future enhancements:

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import Schedule from './pages/Schedule';
 import Courses from './pages/Courses';
 import Fines from './pages/Fines';
 import Friday from './pages/Friday';
+import Scorecard from './pages/Scorecard';
 
 export default function App() {
   const [page, setPage] = useState('home');
@@ -22,6 +23,9 @@ export default function App() {
       break;
     case 'friday':
       content = <Friday />;
+      break;
+    case 'scorecard':
+      content = <Scorecard />;
       break;
     default:
       content = <Home />;

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -6,7 +6,8 @@ export default function Navigation({ current, onNavigate }) {
     { id: 'schedule', label: 'Schedule' },
     { id: 'courses', label: 'Golf Courses' },
     { id: 'fines', label: 'Banter & Fines' },
-    { id: 'friday', label: 'Friday Activities' }
+    { id: 'friday', label: 'Friday Activities' },
+    { id: 'scorecard', label: 'Scorecard' }
   ];
 
   return (

--- a/src/data/scorecards.js
+++ b/src/data/scorecards.js
@@ -1,0 +1,74 @@
+export default {
+  morgado: {
+    name: 'NAU Morgado Course',
+    par: 73,
+    holes: [
+      { par: 4, hcp: 13 },
+      { par: 5, hcp: 3 },
+      { par: 4, hcp: 7 },
+      { par: 5, hcp: 1 },
+      { par: 3, hcp: 15 },
+      { par: 4, hcp: 11 },
+      { par: 4, hcp: 9 },
+      { par: 3, hcp: 17 },
+      { par: 5, hcp: 5 },
+      { par: 4, hcp: 12 },
+      { par: 4, hcp: 4 },
+      { par: 3, hcp: 16 },
+      { par: 4, hcp: 10 },
+      { par: 4, hcp: 2 },
+      { par: 5, hcp: 6 },
+      { par: 3, hcp: 18 },
+      { par: 4, hcp: 14 },
+      { par: 4, hcp: 8 }
+    ]
+  },
+  amendoeira: {
+    name: 'Amendoeira Golf Resort (Faldo Course)',
+    par: 72,
+    holes: [
+      { par: 4, hcp: 9 },
+      { par: 4, hcp: 5 },
+      { par: 4, hcp: 1 },
+      { par: 5, hcp: 7 },
+      { par: 3, hcp: 17 },
+      { par: 4, hcp: 13 },
+      { par: 5, hcp: 3 },
+      { par: 3, hcp: 15 },
+      { par: 4, hcp: 11 },
+      { par: 4, hcp: 10 },
+      { par: 5, hcp: 2 },
+      { par: 4, hcp: 6 },
+      { par: 3, hcp: 18 },
+      { par: 4, hcp: 14 },
+      { par: 4, hcp: 8 },
+      { par: 5, hcp: 4 },
+      { par: 3, hcp: 16 },
+      { par: 4, hcp: 12 }
+    ]
+  },
+  quintadolago: {
+    name: 'Quinta do Lago South Course',
+    par: 71,
+    holes: [
+      { par: 4, hcp: 6 },
+      { par: 5, hcp: 12 },
+      { par: 4, hcp: 2 },
+      { par: 4, hcp: 16 },
+      { par: 3, hcp: 18 },
+      { par: 4, hcp: 8 },
+      { par: 5, hcp: 4 },
+      { par: 3, hcp: 14 },
+      { par: 4, hcp: 10 },
+      { par: 4, hcp: 7 },
+      { par: 4, hcp: 1 },
+      { par: 3, hcp: 17 },
+      { par: 4, hcp: 13 },
+      { par: 4, hcp: 3 },
+      { par: 5, hcp: 11 },
+      { par: 3, hcp: 15 },
+      { par: 4, hcp: 9 },
+      { par: 4, hcp: 5 }
+    ]
+  }
+};

--- a/src/pages/Scorecard.jsx
+++ b/src/pages/Scorecard.jsx
@@ -1,0 +1,166 @@
+import React, { useState, useEffect } from 'react';
+import scorecards from '../data/scorecards';
+
+const STORAGE_KEY = 'golf_trip_scores';
+
+export default function Scorecard() {
+  const courseKeys = Object.keys(scorecards);
+  const [course, setCourse] = useState(courseKeys[0]);
+  const [players, setPlayers] = useState(() => {
+    try {
+      const saved = localStorage.getItem(`${STORAGE_KEY}_players`);
+      return saved ? JSON.parse(saved) : [];
+    } catch {
+      return [];
+    }
+  });
+  const [scores, setScores] = useState(() => {
+    try {
+      const saved = localStorage.getItem(`${STORAGE_KEY}_scores`);
+      return saved ? JSON.parse(saved) : {};
+    } catch {
+      return {};
+    }
+  });
+  const [name, setName] = useState('');
+
+  useEffect(() => {
+    localStorage.setItem(`${STORAGE_KEY}_players`, JSON.stringify(players));
+    localStorage.setItem(`${STORAGE_KEY}_scores`, JSON.stringify(scores));
+  }, [players, scores]);
+
+  const addPlayer = e => {
+    e.preventDefault();
+    if (!name.trim()) return;
+    const id = Date.now().toString();
+    setPlayers(prev => [...prev, { id, name: name.trim() }]);
+    setScores(prev => ({ ...prev, [id]: Array(18).fill('') }));
+    setName('');
+  };
+
+  const handleScoreChange = (pid, hole, value) => {
+    setScores(prev => {
+      const playerScores = prev[pid] || Array(18).fill('');
+      const updated = [...playerScores];
+      updated[hole] = value;
+      return { ...prev, [pid]: updated };
+    });
+  };
+
+  const holeData = scorecards[course].holes;
+
+  const calcTotal = (pid, start, end) => {
+    const playerScores = scores[pid] || [];
+    let total = 0;
+    for (let i = start; i < end; i++) {
+      const v = parseInt(playerScores[i], 10);
+      if (!isNaN(v)) total += v;
+    }
+    return total;
+  };
+
+  return (
+    <section className="page" id="scorecard">
+      <h2>Scorecard</h2>
+      <div className="mt-8">
+        <label className="form-label">Select Course</label>
+        <select
+          className="form-control"
+          value={course}
+          onChange={e => setCourse(e.target.value)}
+        >
+          {courseKeys.map(key => (
+            <option key={key} value={key}>{scorecards[key].name}</option>
+          ))}
+        </select>
+      </div>
+
+      <form className="mt-8" onSubmit={addPlayer}>
+        <div className="form-group">
+          <label className="form-label">Add Player</label>
+          <input
+            className="form-control"
+            value={name}
+            onChange={e => setName(e.target.value)}
+          />
+        </div>
+        <button className="btn btn--primary">Add</button>
+      </form>
+
+      {players.length > 0 && (
+        <div className="scorecard-table-container mt-8">
+          <table className="scorecard-table">
+            <thead>
+              <tr>
+                <th>Hole</th>
+                {holeData.map((_, i) => (
+                  <th key={i}>{i + 1}</th>
+                ))}
+                <th>Out</th>
+                <th>In</th>
+                <th>Total</th>
+              </tr>
+              <tr>
+                <th>Par</th>
+                {holeData.map((h, i) => (
+                  <th key={i}>{h.par}</th>
+                ))}
+                <th>{holeData.slice(0,9).reduce((s,h)=>s+h.par,0)}</th>
+                <th>{holeData.slice(9).reduce((s,h)=>s+h.par,0)}</th>
+                <th>{holeData.reduce((s,h)=>s+h.par,0)}</th>
+              </tr>
+              <tr>
+                <th>Hcp</th>
+                {holeData.map((h, i) => (
+                  <th key={i}>{h.hcp}</th>
+                ))}
+                <th></th>
+                <th></th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {players.map(player => {
+                const out = calcTotal(player.id, 0, 9);
+                const inn = calcTotal(player.id, 9, 18);
+                const total = out + inn;
+                return (
+                  <tr key={player.id}>
+                    <td>{player.name}</td>
+                    {holeData.map((h, i) => {
+                      const val = scores[player.id]?.[i] || '';
+                      let cls = 'score-par';
+                      const num = parseInt(val,10);
+                      if (!isNaN(num)) {
+                        const diff = num - h.par;
+                        if (diff <= -2) cls = 'score-eagle';
+                        else if (diff === -1) cls = 'score-birdie';
+                        else if (diff === 0) cls = 'score-par';
+                        else if (diff === 1) cls = 'score-bogey';
+                        else if (diff >= 2) cls = 'score-double';
+                      }
+                      return (
+                        <td key={i} className={cls}>
+                          <input
+                            type="number"
+                            className="form-control"
+                            value={val}
+                            onChange={e => handleScoreChange(player.id, i, e.target.value)}
+                            style={{ width: '4rem' }}
+                          />
+                        </td>
+                      );
+                    })}
+                    <td>{out || ''}</td>
+                    <td>{inn || ''}</td>
+                    <td>{total || ''}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/style.css
+++ b/src/style.css
@@ -1052,3 +1052,9 @@ main {
 .page.active {
     animation: fadeIn 0.3s ease-in-out;
 }
+.score-eagle{background-color:gold;}
+.score-birdie{background-color:var(--color-success);color:var(--color-btn-primary-text);}
+.score-par{background-color:transparent;}
+.score-bogey{background-color:#fff3cd;}
+.score-double{background-color:#f8d7da;}
+


### PR DESCRIPTION
## Summary
- integrate a new Scorecard page
- add scorecard data for three courses
- link Scorecard in navigation and app routing
- style scoring cells with performance colors
- document new feature in the README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68482bb74e5c83279a717b9147a8c202