### PR TITLE
Fix mobile menu overlay pointer events

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -887,11 +887,13 @@ main {
     z-index: 999;
     opacity: 0;
     transition: opacity 0.3s ease;
+    pointer-events: none;
 }
 
 .mobile-menu-overlay--visible {
     display: block;
     opacity: 1;
+    pointer-events: auto;
 }
 
 /* Mobile styles - CRITICAL MEDIA QUERY */


### PR DESCRIPTION
## Summary
- ensure the hidden mobile overlay can't intercept taps

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68497d87035483279490ca9a0287f74a